### PR TITLE
Add placeholder inserter to TemplateEditor

### DIFF
--- a/src/components/PlaceholderInserter.jsx
+++ b/src/components/PlaceholderInserter.jsx
@@ -1,0 +1,24 @@
+const placeholders = [
+  "{firstName}",
+  "{lastName}",
+  "{jobTitle}",
+  "{company}",
+  "{meetingDate}",
+  "{senderName}",
+];
+
+export default function PlaceholderInserter({ onInsert }) {
+  return (
+    <div className="flex flex-wrap gap-2 mb-4">
+      {placeholders.map((tag) => (
+        <button
+          key={tag}
+          onClick={() => onInsert(tag)}
+          className="px-2 py-1 text-sm bg-muted hover:bg-accent rounded transition"
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/TemplateEditor.jsx
+++ b/src/components/TemplateEditor.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import PlaceholderInserter from "./PlaceholderInserter";
 
 export default function TemplateEditor({ selectedTemplate }) {
   const [title, setTitle] = useState("");
@@ -37,6 +38,10 @@ export default function TemplateEditor({ selectedTemplate }) {
     setTimeout(() => setStatus(""), 2000);
   };
 
+  const handleInsertPlaceholder = (tag) => {
+    setContent((prev) => prev + " " + tag);
+  };
+
   return (
     <div className="bg-card border border-border rounded-xl p-6 shadow-md space-y-4">
       <div>
@@ -52,6 +57,7 @@ export default function TemplateEditor({ selectedTemplate }) {
 
       <div>
         <label className="block font-semibold mb-1">Email Content</label>
+        <PlaceholderInserter onInsert={handleInsertPlaceholder} />
         <textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}


### PR DESCRIPTION
- Adds a button toolbar for inserting common placeholders (e.g. {firstName})
- Inserts placeholder text directly into the email body